### PR TITLE
Remove docker references in 2.1 docs

### DIFF
--- a/v2.1/Admin_manuals/configuration.adoc
+++ b/v2.1/Admin_manuals/configuration.adoc
@@ -209,9 +209,6 @@ This chapter describes the structure of the ETF data directory. The following
 figure shows an example structure, identifiers or version numbers may be
 different in your setup.
 
-NOTE: When ETF is started from a docker image not all directories are mounted
-on the host.
-
 .ETF data directory
 image::../images/etf-data-dir.png[ETF data directory]
 

--- a/v2.1/Admin_manuals/index.html
+++ b/v2.1/Admin_manuals/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.10">
 <title>Administration of an ETF validator</title>
 <link rel="stylesheet" href="../stylesheets/etf.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -71,7 +71,7 @@ Testing framework for spatial data and services</span></p></td>
 <h1 id="_administration_of_an_etf_validator" class="sect0">Administration of an ETF validator</h1>
 <div class="openblock partintro">
 <div class="content">
-<table class="tableblock frame-ends grid-none stretch">
+<table class="tableblock frame-topbot grid-none stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 75%;">
@@ -224,7 +224,7 @@ Testing framework for spatial data and services</span></p></td>
 </ul>
 </div>
 <div class="paragraph">
-<p>Each Test Driver can be installed in the <a href="Admin_manuals/index.html#_etf_data_directory_structure">test driver directory</a> (fallback <strong>%ALLUSERSPROFILE%\etf\td</strong> ) and will be used by ETF on startup.</p>
+<p>Each Test Driver can be installed in the <a href="https://docs.etf-validator.net/v2.1/Admin_manuals/index.html#_etf_data_directory_structure">test driver directory</a> and will be used by ETF on startup.</p>
 </div>
 <div class="paragraph">
 <p>Copy the etf-webapp.war file to <strong>JETTY_HOME/webapps</strong> or if you have created a JETTY_BASE, then copy the etf-webapp.war file to <strong>JETTY_BASE/webapps</strong>.</p>
@@ -317,7 +317,7 @@ To stop the process use <strong>CTRL+C</strong>.
 </ul>
 </div>
 <div class="paragraph">
-<p>Each Test Driver can be installed in the <a href="Admin_manuals/index.html#_etf_data_directory_structure">test driver directory</a> and will be used by ETF on startup.</p>
+<p>Each Test Driver can be installed in the <a href="https://docs.etf-validator.net/v2.1/Admin_manuals/index.html#_etf_data_directory_structure">test driver directory</a> and will be used by ETF on startup.</p>
 </div>
 <div class="paragraph">
 <p>Copy the etf-webapp.war file to <strong>JETTY_HOME/webapps</strong> or if you have created a JETTY_BASE, then copy the etf-webapp.war file to <strong>JETTY_BASE/webapps</strong>.</p>
@@ -622,19 +622,6 @@ etf.webapp.base.url = http://localhost:8080/etf-webapp
 figure shows an example structure, identifiers or version numbers may be
 different in your setup.</p>
 </div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<i class="fa icon-note" title="Note"></i>
-</td>
-<td class="content">
-When ETF is started from a docker image not all directories are mounted
-on the host.
-</td>
-</tr>
-</table>
-</div>
 <div class="imageblock">
 <div class="content">
 <img src="../images/etf-data-dir.png" alt="ETF data directory">
@@ -785,7 +772,7 @@ The GmlGeoX module will be automatically reinstalled.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-08-24 22:33:25 +0200
+Last updated 2022-10-04 09:10:55 +0200
 </div>
 </div>
 </body>

--- a/v2.1/General/About.adoc
+++ b/v2.1/General/About.adoc
@@ -14,6 +14,4 @@ The concepts in ETF are based on ISO 19105 and the OGC Specification Model which
 
 ETF can be used via a responsive web application or via a link:http://docs.etf-validator.net/Developer_manuals/WEB-API.html#_overview[REST API].
 
-The easiest way to deploy ETF is a Docker container, available on link:https://hub.docker.com/r/iide/etf-webapp[Docker Hub].
-
 link:http://www.interactive-instruments.de/[interactive instruments] has developed ETF and is the primary maintainer of the software.

--- a/v2.1/index.html
+++ b/v2.1/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.10">
 <title>ETF manuals</title>
 <link rel="stylesheet" href="stylesheets/etf.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -84,9 +84,6 @@ Testing framework for spatial data and services</span></p></td>
 <p>ETF can be used via a responsive web application or via a <a href="http://docs.etf-validator.net/Developer_manuals/WEB-API.html#_overview">REST API</a>.</p>
 </div>
 <div class="paragraph">
-<p>The easiest way to deploy ETF is a Docker container, available on <a href="https://hub.docker.com/r/iide/etf-webapp">Docker Hub</a>.</p>
-</div>
-<div class="paragraph">
 <p><a href="http://www.interactive-instruments.de/">interactive instruments</a> has developed ETF and is the primary maintainer of the software.</p>
 </div>
 </div>
@@ -156,7 +153,7 @@ This work was supported by the <a href="http://ec.europa.eu/isa">EU Interoperabi
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-08-24 21:09:56 +0200
+Last updated 2022-10-04 09:10:55 +0200
 </div>
 </div>
 </body>


### PR DESCRIPTION
PR to remove references to Docker deployment of the ETF in .adoc files.
Please note that .html files have been generated according to the changes introduced in .adoc files.